### PR TITLE
Remove more restrictions on versions

### DIFF
--- a/gradm-runtime/src/main/kotlin/me/omico/gradm/internal/config/Versions.kt
+++ b/gradm-runtime/src/main/kotlin/me/omico/gradm/internal/config/Versions.kt
@@ -42,7 +42,7 @@ private fun Map<*, *>.toMutableFlatVersions(parentKey: String, versions: Mutable
         versions
     }
 
-private val flatKeyRegex = Regex("^[a-zA-Z\\d]+([.-][a-zA-Z\\d]+)?")
+private val flatKeyRegex = Regex("^[a-zA-Z\\d]+(([.-][a-zA-Z\\d]+)+)?")
 
 private fun subFlatKey(key: Any?): String =
     run {


### PR DESCRIPTION
Currently, the below code will throw an error.
```yaml
versions:
  retrofit.converter.kotlinx.serialization: "0.8.0" // error here
```
You can use the code below as a workaround.
```yaml
versions:
  retrofit.converter:
    kotlinx.serialization: "0.8.0" // work as we expect
```