### PR TITLE
No longer required copy Gradle wrapper

### DIFF
--- a/gradm-codegen/src/main/kotlin/me/omico/gradm/internal/codegen/CodeGenerator.kt
+++ b/gradm-codegen/src/main/kotlin/me/omico/gradm/internal/codegen/CodeGenerator.kt
@@ -19,8 +19,6 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FileSpec
 import me.omico.gradm.VersionsMeta
 import me.omico.gradm.internal.YamlDocument
-import me.omico.gradm.path.GradleRootProjectPaths
-import me.omico.gradm.path.copyGradleWrapperToGradmFolder
 import me.omico.gradm.path.gradmGeneratedDependenciesProjectPaths
 import me.omico.gradm.path.sourceFolder
 import me.omico.gradm.utility.clearDirectory
@@ -30,7 +28,6 @@ import kotlin.io.path.createDirectories
 internal fun generateDependenciesProjectFiles(document: YamlDocument, versionsMeta: VersionsMeta) {
     if (versionsMeta.isEmpty()) return
     gradmGeneratedDependenciesProjectPaths.path.createDirectories()
-    GradleRootProjectPaths.copyGradleWrapperToGradmFolder()
     generateGradleBuildScript()
     generateGradleSettingsScript()
     gradmGeneratedDependenciesProjectPaths.sourceFolder.clearDirectory()

--- a/gradm-runtime/src/main/kotlin/me/omico/gradm/path/GradleProjectPaths.kt
+++ b/gradm-runtime/src/main/kotlin/me/omico/gradm/path/GradleProjectPaths.kt
@@ -30,24 +30,6 @@ interface GradleRootProjectPaths : GradleProjectPaths {
     }
 }
 
-inline val GradleRootProjectPaths.gradleFolder: Path
-    get() = path.resolve("gradle")
-
-inline val GradleRootProjectPaths.gradleWrapperFolder: Path
-    get() = gradleFolder.resolve("wrapper")
-
-inline val GradleRootProjectPaths.gradleWrapperJar: Path
-    get() = gradleWrapperFolder.resolve("gradle-wrapper.jar")
-
-inline val GradleRootProjectPaths.gradleWrapperProperties: Path
-    get() = gradleWrapperFolder.resolve("gradle-wrapper.properties")
-
-inline val GradleRootProjectPaths.gradleWrapperScript: Path
-    get() = path.resolve("gradlew")
-
-inline val GradleRootProjectPaths.gradleWrapperBatScript: Path
-    get() = path.resolve("gradlew.bat")
-
 inline val GradleProjectPaths.gradleBuildScript: Path
     get() = path.resolve("build.gradle.kts")
 

--- a/gradm-runtime/src/main/kotlin/me/omico/gradm/path/GradmProjectPaths.kt
+++ b/gradm-runtime/src/main/kotlin/me/omico/gradm/path/GradmProjectPaths.kt
@@ -16,8 +16,6 @@
 package me.omico.gradm.path
 
 import java.nio.file.Path
-import kotlin.io.path.copyTo
-import kotlin.io.path.createDirectories
 
 @JvmInline
 value class GradmProjectPaths(override val path: Path) : GradleRootProjectPaths
@@ -48,13 +46,3 @@ inline val GradmProjectPaths.updatesFolder: Path
 
 inline val GradmProjectPaths.updatesAvailableFile: Path
     get() = updatesFolder.resolve("available.yml")
-
-fun GradleRootProjectPaths.copyGradleWrapperToGradmFolder() {
-    val gradmProjectPaths = GradmProjectPaths(path = path.resolve(".gradm"))
-    gradmProjectPaths.path.createDirectories()
-    gradmProjectPaths.gradleWrapperFolder.createDirectories()
-    gradleWrapperJar.copyTo(gradmProjectPaths.gradleWrapperJar, overwrite = true)
-    gradleWrapperProperties.copyTo(gradmProjectPaths.gradleWrapperProperties, overwrite = true)
-    gradleWrapperScript.copyTo(gradmProjectPaths.gradleWrapperScript, overwrite = true)
-    gradleWrapperBatScript.copyTo(gradmProjectPaths.gradleWrapperBatScript, overwrite = true)
-}


### PR DESCRIPTION
Besides, there has a mistake in the `copyGradleWrapperToGradmFolder()`. `gradmProjectPaths` should be `GradmProjectPaths(path = path.resolve(".gradm").resolve("generated-dependencies"))`.