### PR TITLE
Initial support for Gradle Configuration Cache

### DIFF
--- a/examples/gradm-getting-started/build.gradle.kts
+++ b/examples/gradm-getting-started/build.gradle.kts
@@ -12,6 +12,14 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = versions.androidx.compose.compiler
     }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+kotlin {
+    jvmToolchain(11)
 }
 
 dependencies {

--- a/examples/gradm-getting-started/gradle.properties
+++ b/examples/gradm-getting-started/gradle.properties
@@ -4,5 +4,6 @@ android.useAndroidX=true
 kotlin.code.style=official
 
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.parallel=true

--- a/examples/gradm-getting-started/src/main/kotlin/MainActivity.kt
+++ b/examples/gradm-getting-started/src/main/kotlin/MainActivity.kt
@@ -1,0 +1,3 @@
+import androidx.activity.ComponentActivity
+
+class MainActivity : ComponentActivity()

--- a/examples/gradm-with-composite-build/build-logic/convention/build.gradle.kts
+++ b/examples/gradm-with-composite-build/build-logic/convention/build.gradle.kts
@@ -7,4 +7,5 @@ dependencies {
     implementation(com.diffplug.spotless)
     implementation(gradmGeneratedJar)
     implementation(me.omico.age.spotless)
+    implementation(org.jetbrains.kotlin.android)
 }

--- a/examples/gradm-with-composite-build/build-logic/convention/src/main/kotlin/build-logic.android.library.gradle.kts
+++ b/examples/gradm-with-composite-build/build-logic/convention/src/main/kotlin/build-logic.android.library.gradle.kts
@@ -1,6 +1,7 @@
 @file:Suppress("UnstableApiUsage")
 
 plugins {
+    kotlin("android")
     id("com.android.library")
 }
 
@@ -14,4 +15,12 @@ android {
         // You must add gradmGeneratedJar to dependencies, otherwise you won't be able to use.
         kotlinCompilerExtensionVersion = versions.androidx.compose.compiler
     }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+kotlin {
+    jvmToolchain(11)
 }

--- a/examples/gradm-with-composite-build/example/src/main/kotlin/MainActivity.kt
+++ b/examples/gradm-with-composite-build/example/src/main/kotlin/MainActivity.kt
@@ -1,0 +1,3 @@
+import androidx.activity.ComponentActivity
+
+class MainActivity : ComponentActivity()

--- a/examples/gradm-with-composite-build/gradle.properties
+++ b/examples/gradm-with-composite-build/gradle.properties
@@ -4,5 +4,6 @@ android.useAndroidX=true
 kotlin.code.style=official
 
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.parallel=true

--- a/gradm-gradle-plugin/src/main/kotlin/me/omico/gradm/GradmPlugin.kt
+++ b/gradm-gradle-plugin/src/main/kotlin/me/omico/gradm/GradmPlugin.kt
@@ -25,6 +25,7 @@ import me.omico.gradm.internal.GradmFormatExtensionImpl
 import me.omico.gradm.path.gradmGeneratedSourcesDirectory
 import me.omico.gradm.task.GradmDependencyUpdates
 import me.omico.gradm.task.GradmGenerator
+import me.omico.gradm.task.setup
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
@@ -80,13 +81,11 @@ private fun Project.configureGradmGenerator(
     gradmWorkerServiceProvider: Provider<GradmWorkerService>,
 ) {
     val generateGradmSources = tasks.register<GradmGenerator>("generateGradmSources") {
-        usesService(gradmWorkerServiceProvider)
-        workerServiceProperty.set(gradmWorkerServiceProvider)
-        configFileProperty.convention { file(gradmExtension.configFilePath) }
-        outputDirectoryProperty.convention(gradmGeneratedSourcesDirectory)
+        setup(gradmExtension, gradmWorkerServiceProvider)
+        gradmGeneratedSourcesDirectoryProperty.convention(gradmGeneratedSourcesDirectory)
     }
     val sourceSets = extensions.getByType<SourceSetContainer>()
-    sourceSets["main"].java.srcDir(generateGradmSources.flatMap(GradmGenerator::outputDirectoryProperty))
+    sourceSets["main"].java.srcDir(generateGradmSources.flatMap(GradmGenerator::gradmGeneratedSourcesDirectoryProperty))
 }
 
 private fun Project.configureGradmDependencyUpdates(
@@ -94,8 +93,6 @@ private fun Project.configureGradmDependencyUpdates(
     gradmWorkerServiceProvider: Provider<GradmWorkerService>,
 ) {
     tasks.register<GradmDependencyUpdates>("gradmDependencyUpdates") {
-        workerServiceProperty.set(gradmWorkerServiceProvider)
-        usesService(gradmWorkerServiceProvider)
-        configFileProperty.convention { file(gradmExtension.configFilePath) }
+        setup(gradmExtension, gradmWorkerServiceProvider)
     }
 }

--- a/gradm-gradle-plugin/src/main/kotlin/me/omico/gradm/task/GradmDependencyUpdates.kt
+++ b/gradm-gradle-plugin/src/main/kotlin/me/omico/gradm/task/GradmDependencyUpdates.kt
@@ -22,7 +22,8 @@ abstract class GradmDependencyUpdates : GradmTask() {
     @TaskAction
     fun execute() {
         workerService.refresh(
-            project = project,
+            dependencies = dependencies,
+            gradmProjectPaths = gradmProjectPaths,
             gradmConfigFile = gradmConfigFile,
         )
     }

--- a/gradm-gradle-plugin/src/main/kotlin/me/omico/gradm/task/GradmGenerator.kt
+++ b/gradm-gradle-plugin/src/main/kotlin/me/omico/gradm/task/GradmGenerator.kt
@@ -23,15 +23,16 @@ import org.gradle.api.tasks.TaskAction
 @CacheableTask
 abstract class GradmGenerator : GradmTask() {
 
-    abstract val outputDirectoryProperty: DirectoryProperty
+    abstract val gradmGeneratedSourcesDirectoryProperty: DirectoryProperty
         @OutputDirectory get
 
     @TaskAction
     fun execute() {
         workerService.generate(
-            project = project,
+            dependencies = dependencies,
+            gradmProjectPaths = gradmProjectPaths,
             gradmConfigFile = gradmConfigFile,
-            outputDirectory = outputDirectoryProperty.asFile.get().toPath(),
+            outputDirectory = gradmGeneratedSourcesDirectoryProperty.asFile.get().toPath(),
         )
     }
 }

--- a/gradm-runtime/src/main/kotlin/me/omico/gradm/internal/maven/bom/MavenPomPomResolver.kt
+++ b/gradm-runtime/src/main/kotlin/me/omico/gradm/internal/maven/bom/MavenPomPomResolver.kt
@@ -19,12 +19,12 @@ import me.omico.gradm.VersionsMeta
 import me.omico.gradm.internal.YamlDocument
 import me.omico.gradm.internal.config.Dependency
 import me.omico.gradm.internal.config.dependencies
-import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.maven.MavenModule
 import org.gradle.maven.MavenPomArtifact
 
-internal fun Project.resolveBomVersionsMeta(document: YamlDocument): VersionsMeta =
+internal fun DependencyHandler.resolveBomVersionsMeta(document: YamlDocument): VersionsMeta =
     document
         .dependencies
         .filter(Dependency::bom)
@@ -32,9 +32,8 @@ internal fun Project.resolveBomVersionsMeta(document: YamlDocument): VersionsMet
         .flatMap(MavenBomPom::dependencies)
         .associate { it.module to it.version }
 
-private fun Project.MavenBomPom(dependency: Dependency): MavenBomPom =
-    dependencies
-        .createArtifactResolutionQuery()
+private fun DependencyHandler.MavenBomPom(dependency: Dependency): MavenBomPom =
+    createArtifactResolutionQuery()
         .forModule(dependency.group, dependency.artifact, dependency.version!!)
         .withArtifacts(MavenModule::class.java, MavenPomArtifact::class.java)
         .execute()

--- a/gradm-runtime/src/main/kotlin/me/omico/gradm/path/GradmProjectPaths.kt
+++ b/gradm-runtime/src/main/kotlin/me/omico/gradm/path/GradmProjectPaths.kt
@@ -17,6 +17,8 @@ package me.omico.gradm.path
 
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import java.nio.file.Path
 import kotlin.io.path.div
@@ -25,11 +27,10 @@ import kotlin.io.path.name
 @JvmInline
 value class GradmProjectPaths(val path: Path)
 
+fun ProjectLayout.gradmConfigFile(path: String): RegularFile = projectDirectory.file(path)
+
 inline val Project.gradmGeneratedSourcesDirectory: Provider<Directory>
     get() = layout.buildDirectory.dir("generated/sources/gradm/kotlin/main")
-
-inline val Project.gradmProjectPaths: GradmProjectPaths
-    get() = GradmProjectPaths(projectDir.toPath())
 
 inline val GradmProjectPaths.projectName: String
     get() = path.name


### PR DESCRIPTION
The Gradle Configuration Cache currently is not yet implemented for [source dependencies](https://blog.gradle.org/introducing-source-dependencies). This PR is just the initial implementation of it and I will continue to develop it once the upstream implement. See also, #49.