### PR TITLE
New version identification rules

### DIFF
--- a/gradm-runtime/src/main/kotlin/me/omico/gradm/internal/maven/Version.kt
+++ b/gradm-runtime/src/main/kotlin/me/omico/gradm/internal/maven/Version.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Omico
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.omico.gradm.internal.maven
+
+data class Version(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+    val qualifier: String?,
+    val value: String,
+) : Comparable<Version> {
+    override fun compareTo(other: Version): Int {
+        var result = compareValuesBy(this, other, Version::major, Version::minor, Version::patch)
+        if (result != 0) return result
+        val otherQualifier = other.qualifier
+        if (qualifier == otherQualifier) return 0
+        if (qualifier == null) return 1
+        if (otherQualifier == null) return -1
+        val thisQualifierResult = QualifierRegex.matchEntire(qualifier.lowercase())
+        val otherQualifierResult = QualifierRegex.matchEntire(otherQualifier.lowercase())
+        if (thisQualifierResult?.value == otherQualifierResult?.value) return 0
+        if (thisQualifierResult == null) return 1
+        if (otherQualifierResult == null) return -1
+        result = compareValuesBy(thisQualifierResult.groupValues[1], otherQualifierResult.groupValues[1]) {
+            QUALIFIERS.getOrDefault(it, 0)
+        }
+        if (result != 0) return result
+        result = compareValues(
+            a = thisQualifierResult.groupValues[2].toInt(),
+            b = otherQualifierResult.groupValues[2].toInt(),
+        )
+        return result
+    }
+
+    override fun toString(): String = value
+
+    companion object {
+        fun parse(version: String): Version = run {
+            val versionSplit = version.split("-", limit = 2)
+            val versionNumbers = versionSplit.first().split(".").mapNotNull(String::toIntOrNull)
+            Version(
+                major = versionNumbers.getOrElse(0) { 0 },
+                minor = versionNumbers.getOrElse(1) { 0 },
+                patch = versionNumbers.getOrElse(2) { 0 },
+                qualifier = versionSplit.getOrNull(1),
+                value = version,
+            )
+        }
+    }
+}
+
+private val QualifierRegex: Regex = Regex("(alpha|beta|milestone|rc|snapshot)([0-9]{2})?")
+
+private val QUALIFIERS: Map<String, Int> =
+    mapOf(
+        "snapshot" to -5,
+        "alpha" to -4,
+        "beta" to -3,
+        "milestone" to -2,
+        "rc" to -1,
+        "" to 0,
+    )

--- a/gradm-runtime/src/test/kotlin/me/omico/gradm/internal/maven/VersionTest.kt
+++ b/gradm-runtime/src/test/kotlin/me/omico/gradm/internal/maven/VersionTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Omico
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.omico.gradm.internal.maven
+
+import org.junit.jupiter.api.Test
+
+class VersionTest {
+    @Test
+    fun `1_2_0-alpha01 same as 1_2_0-alpha01`() {
+        assert(Version.parse("1.2.0-alpha01") == Version.parse("1.2.0-alpha01"))
+    }
+
+    @Test
+    fun `1_2_0-alpha01 older than 1_2_0-alpha02`() {
+        assert(Version.parse("1.2.0-alpha01") < Version.parse("1.2.0-alpha02"))
+    }
+
+    @Test
+    fun `1_2_0-rc01 newer than 1_2_0-alpha02`() {
+        assert(Version.parse("1.2.0-rc01") > Version.parse("1.2.0-alpha02"))
+    }
+
+    @Test
+    fun `1_2_0-SNAPSHOT older than 1_2_0-rc02`() {
+        assert(Version.parse("1.2.0-SNAPSHOT") < Version.parse("1.2.0-rc02"))
+    }
+
+    @Test
+    fun `1_2_0 newer than 1_2_0-SNAPSHOT`() {
+        assert(Version.parse("1.2.0") > Version.parse("1.2.0-SNAPSHOT"))
+    }
+}


### PR DESCRIPTION
The new version identification rules aim to fix some weird unformatted `maven-metadata.xml`.

Here is a comparison of the result of `org.jetbrains.compose` plugin.

### org.jetbrains.compose v1.4.0 (Before)

<details><summary>TOO LONG, click me to view the full content.</summary>
<p>

```yaml
plugins:
  org.jetbrains.compose:
    - 0.1.0-build60
    - 0.1.0-build62
    - 0.1.0-unmerged37
    - 0.1.0-unmerged38
    - 0.1.0-build63
    - 0.1.0-dev68
    - 0.1.0-dev84
    - 0.1.0-dev85
    - 0.1.0-dev87
    - 0.1.0-dev93
    - 0.1.0-dev94
    - 0.1.0-dev95
    - 0.1.0-dev96
    - 0.1.0-dev97
    - 0.1.0-dev101
    - 0.1.0-dev102
    - 0.1.0-dev104
    - 0.1.0-dev106
    - 0.1.0-dev107
    - 0.1.0-dev109
    - 0.1.0-m1-build57
    - 0.1.0-m1-build59
    - 0.1.0-m1-build61
    - 0.1.0-m1-build62
    - 0.1.0-build112
    - 0.1.0-build113
    - 0.1.0-build114
    - 0.1.0-build117
    - 0.1.0-build118
    - 0.1.0-build119
    - 0.2.0-build122
    - 0.0.0-unmerged-build6
    - 0.0.0-swingcfd-build10
    - 0.2.0-build123
    - 0.2.0-build124
    - 0.0.0-unmerged-build11
    - 0.0.0-macarm-build12
    - 0.2.0-build125
    - 0.2.0-build126
    - 0.2.0-build127
    - 0.2.0-build128
    - 0.0.0-unmerged-build13
    - 0.2.0-build129
    - 0.2.0-build130
    - 0.2.0-build131
    - 0.2.0-build132
    - 0.0.0-unmerged-build14
    - 0.3.0-build133
    - 0.0.0-unmerged-build15
    - 0.3.0-build134
    - 0.0.0-renderinglog-build16
    - 0.3.0-build135
    - 0.0.0-unmerged-build17
    - 0.0.0-unmerged-build18
    - 0.0.0-skiko0120-build19
    - 0.3.0-build136
    - 0.0.0-unmerged-build20
    - 0.0.0-unmerged-build21
    - 0.0.0-unmerged-build22
    - 0.3.0-build137
    - 0.3.0-build138
    - 0.0.0-unmerged-build23
    - 0.3.0-build139
    - 0.0.0-unmerged-build24
    - 0.3.0-build140
    - 0.0.0-unmerged-build25
    - 0.3.0-build141
    - 0.0.0-vsync-build26
    - 0.0.0-unmerged-build28
    - 0.0.0-vsync-build29
    - 0.0.0-vsync-build30
    - 0.3.0-build142
    - 0.0.0-unmerged-build31
    - 0.3.0-build143
    - 0.0.0-unmerged-build32
    - 0.3.0-build145
    - 0.3.0-build146
    - 0.0.0-unmerged-build33
    - 0.3.0-build147
    - 0.3.0-build148
    - 0.3.0-build149
    - 0.3.0-build150
    - 0.0.0-unmerged-build34
    - 0.3.0-build152
    - 0.0.0-unmerged-build35
    - 0.3.0-build153
    - 0.3.0-build154
    - 0.0.0-unmerged-build37
    - 0.0.0-unmerged-build38
    - 0.0.0-unmerged-build39
    - 0.3.0-rc1
    - 0.3.0
    - 0.0.0-unmerged-build40
    - 0.4.0-build168
    - 0.3.1
    - 0.4.0-build171
    - 0.0.0-unmerged-build41
    - 0.3.2
    - 0.0.0-unmerged-build43
    - 0.0.0-unmerged-build44
    - 0.4.0-build173
    - 0.4.0-build174
    - 0.0.0-unmerged-build46
    - 0.4.0-build175
    - 0.4.0-build176
    - 0.4.0-build177
    - 0.0.0-unmerged-build47
    - 0.4.0-build178
    - 0.0.0-unmerged-build58
    - 0.4.0-build179
    - 0.4.0-build180
    - 0.4.0-build181
    - 0.0.0-unmerged-build59
    - 0.4.0-build182
    - 0.4.0-build183
    - 0.0.0-unmerged-build60
    - 0.0.0-unmerged-build61
    - 0.4.0-build184
    - 0.0.0-unmerged-build62
    - 0.4.0-build185
    - 0.0.0-unmerged-build63
    - 0.0.0-unmerged-preview-build64
    - 0.0.0-web-dev-2
    - 0.0.0-web-dev-3
    - 0.0.0-web-dev-5
    - 0.0.2-SNAPSHOT
    - 0.0.3-SNAPSHOT
    - 0.0.0-web-dev-6
    - 0.0.4-SNAPSHOT
    - 0.0.0-web-dev-7
    - 0.0.0-web-dev-8
    - 0.0.0-web-dev-9
    - 0.0.0-web-dev-10
    - 0.0.5-SNAPSHOT
    - 0.0.6-SNAPSHOT
    - 0.0.0-web-deb-11
    - 0.0.0-web-dev-11
    - 0.4.0-build187
    - 0.4.0-build188
    - 0.0.0-web-dev-12
    - 0.0.0-unmerged-build71
    - 0.0.0-unmerged-build73
    - 0.4.0-build190
    - 0.0.0-unmerged-gradle-7-build79
    - 0.0.0-unmerged-build80
    - 0.4.0-build198
    - 0.0.8-SNAPSHOT
    - 0.4.0-build208
    - 0.4.0-build209
    - 0.0.9-SNAPSHOT
    - 0.0.10-SNAPSHOT
    - 0.4.0-build210
    - 0.0.11-SNAPSHOT
    - 0.4.0-build211
    - 0.0.0-web-dev-13
    - 0.0.12-SNAPSHOT
    - 0.4.0-build212
    - 0.4.0-rc1
    - 0.4.0-rc2
    - 0.4.0-rc3
    - 0.4.0
    - 0.0.0-web-dev-14
    - 0.0.0-unmerged-build78
    - 0.0.0-web-dev-14.1
    - 0.0.0-unmerged-build79
    - 0.0.14-SNAPSHOT
    - 0.0.0-unmerged-build81
    - 0.0.0-unmerged-build82
    - 0.0.0-unmerged-build83
    - 0.0.15-SNAPSHOT
    - 0.0.0-unmerged-build84
    - 0.5.0-build218
    - 0.0.0-unmerged-build85
    - 0.5.0-build219
    - 0.5.0-build220
    - 0.5.0-build221
    - 0.5.0-build222
    - 0.5.0-build223
    - 0.5.0-build224
    - 0.0.0-unmerged-build86
    - 0.5.0-build225
    - 0.0.0-unmerged-build87
    - 0.5.0-build226
    - 0.0.0-non-interactive-preview-build89
    - 0.0.0-non-interactive-preview-build89-1
    - 0.0.0-non-interactive-preview-build89-2
    - 0.0.0-non-interactive-preview-build89-3
    - 0.0.0-non-interactive-preview-build89-4
    - 0.0.0-unmerged-build91
    - 0.0.0-unmerged-build92
    - 0.0.0-unmerged-build93
    - 0.5.0-build227
    - 0.0.0-newci-264
    - 0.0.0-unmerged-build94
    - 0.0.0-newci-308
    - 0.0.0-newci-315
    - 0.0.0-newci-316
    - 0.0.0-unmerged-build95
    - 0.5.0-build228
    - 0.0.0-custom-build322
    - 0.0.0-sync-2021-06-30-build334
    - 0.0.0-SNASPHOT
    - 0.5.0-build229
    - 0.5.0-build235
    - 0.0.0-sync-2021-07-12-with-web-fix-build241
    - 0.5.0-build243
    - 0.0.0-sync-2021-07-13-build244
    - 0.5.0-build245
    - 0.0.0-preview-loading
    - 0.5.0-build253
    - 0.0.0-sync-2021-07-19-build258
    - 0.0.0-sync-2021-07-19-build259
    - 0.0.0-sync-2021-07-19-build260
    - 0.5.0-build262
    - 0.0.0-sync-2021-07-23-build267
    - 0.5.0-build270
    - 0.0.0-master-build272
    - 0.0.0-sync-2021-07-28-build278
    - 0.0.0-sync-2021-07-28-build280
    - 0.0.0-sync-2021-07-28-build290
    - 1.0.0-alpha1-rc1
    - 1.0.0-alpha1-rc2
    - 1.0.0-alpha1-rc
    - 1.0.0-alpha1-rc3
    - 1.0.0-alpha1-rc4
    - 1.0.0-alpha1-rc5
    - 1.0.0-alpha1
    - 1.0.0-alpha2
    - 1.0.0-alpha3
    - 1.0.0-alpha4-build310
    - 1.0.0-alpha4-build315
    - 0.0.0-master-build316
    - 1.0.0-alpha4-build318
    - 1.0.0-alpha4-build321
    - 0.0.0-sync-2021-08-26-build325
    - 0.0.0-sync-2021-08-27-build327
    - 1.0.0-alpha4-build328
    - 1.0.0-alpha4-build331
    - 0.0.0-sync-2021-09-08-build341
    - 1.0.0-alpha4-build343
    - 1.0.0-alpha4-build344
    - 1.0.0-alpha4-build348
    - 0.0.0-master-build352
    - 0.0.0-feature-publishing-experiments-build358
    - 1.0.0-alpha4-build361
    - 1.0.0-alpha4-build362
    - 0.0.0-sync-2021-09-28-build364
    - 0.0.0-sync-2021-09-28-build365
    - 1.0.0-alpha4-build366
    - 0.0.0-master-build377
    - 0.0.0-sync-2010-10-01-build378
    - 0.0.0-fastci-build379
    - 0.0.0-fastci-build383
    - 0.0.0-fastci-build384
    - 1.0.0-alpha4-build385
    - 0.0.0-sync-2010-10-01-build393
    - 0.0.0-sync-2010-10-01-build394
    - 1.0.0-alpha4-build396
    - 0.0.0-master-build397
    - 1.0.0-alpha4-build398
    - 0.0.0-master-build399
    - 0.0.0-master-build401
    - 0.0.0-sync-2021-10-12-build403
    - 0.0.0-master-build404
    - 0.0.0-sync-2021-10-12-build405
    - 0.0.0-sync-2021-10-12-build407
    - 0.0.0-sync-2021-10-12-build409
    - 0.0.0-master-build410
    - 1.0.0-alpha4-build411
    - 0.0.0-master-build413
    - 0.0.0-master-build414
    - 0.0.0-master-build415
    - 0.0.0-master-build416
    - 0.0.0-master-build417
    - 1.0.0-alpha4-build418
    - 0.0.0-master-build200
    - 0.0.0-master-build201
    - 0.0.0-master-build202
    - 0.0.0-master-build423
    - 1.0.0-beta1
    - 0.0.0-master-dev428
    - 0.0.0-master-dev429
    - 0.0.0-master-dev430
    - 1.0.0-beta2
    - 1.0.0-beta3
    - 0.0.0-master-dev435
    - 1.0.0-beta4-dev436
    - 0.0.0-release-1.0-beta-dev438
    - 0.0.0-master-dev439
    - 1.0.0-beta4
    - 1.0.0-beta5
    - 0.0.0-master-dev443
    - 0.0.0-master-dev444
    - 0.0.0-master-dev445
    - 1.0.0-beta6-dev446
    - 0.0.0-master-dev447
    - 0.0.0-master-dev448
    - 0.0.0-master-dev449
    - 1.0.0-beta6-dev450
    - 0.0.0-master-dev451
    - 0.0.0-use_new_compose_version-dev452
    - 0.0.0-master-dev453
    - 1.0.0-beta6-dev454
    - 1.0.0-beta6-dev455
    - 0.0.0-master-dev456
    - 0.0.0-use_new_compose_version-dev457
    - 0.0.0-use_new_compose_version-dev458
    - 0.0.0-use_new_compose_version-dev459
    - 0.0.0-feature-material3-build460
    - 0.0.0-master-dev461
    - 1.0.0-beta6-dev462
    - 0.0.0-master-dev463
    - 1.0.0-beta6-dev464
    - 0.0.0-master-dev465
    - 0.0.0-use_new_compose_version-dev466_160_beta02
    - 0.0.0-use_new_compose_version-dev467
    - 0.0.0-use_new_compose_version-dev468
    - 0.0.0-master-dev469
    - 0.0.0-master-dev470
    - 0.0.0-master-dev471
    - 0.0.0-master-dev473
    - 1.0.0-beta6-dev474
    - 0.0.0-master-dev475
    - 1.0.0-rc1
    - 0.0.0-master-dev477
    - 1.0.0-beta6-dev478
    - 1.0.0-rc2
    - 1.0.0-rc3
    - 0.0.0-master-dev483
    - 0.0.0-master-dev484
    - 1.0.0-rc4
    - 0.0.0-master-dev486
    - 1.0.0-rc5
    - 0.0.0-master-dev488
    - 0.0.0-feature-test27112021-dev489
    - 0.0.0-feature-test28112021-dev491
    - 1.0.0-rc6
    - 0.0.0-master-dev493
    - 1.0.0-beta6-dev494
    - 1.0.0-rc7
    - 1.0.0-rc8
    - 1.0.0-rc9
    - 1.0.0-rc10
    - 0.0.0-master-dev499
    - 1.0.0-rc11
    - 1.0.0-rc12
    - 1.0.0
    - 0.0.0-master-dev503
    - 0.0.0-master-dev504
    - 0.0.0-master-dev505
    - 0.0.0-master-dev506
    - 1.1.0-alpha1-dev507
    - 0.0.0-use_new_compose_version-dev508
    - 0.0.0-master-dev509
    - 0.0.0-master-dev510
    - 0.0.0-master-dev511
    - 0.0.0-use_kotlin_1.6.10-RC-dev512
    - 0.0.0-master-dev513
    - 0.0.0-master-dev516
    - 0.0.0-master-dev517
    - 0.0.0-use_kotlin_1.6.10-RC-dev518
    - 0.0.0-use_kotlin_1.6.10-RC-dev519
    - 0.0.0-use_kotlin_1.6.10-RC-dev520
    - 0.0.0-use_kotlin_1.6.10-RC-dev521
    - 0.0.0-master-dev522
    - 1.0.1-rc1
    - 0.0.0-master-dev526
    - 1.1.0-alpha1-dev527
    - 0.0.0-1.0.1-rc1-using-kotlin1.6.10-dev529
    - 1.0.1-rc2
    - 0.0.0-master-dev533
    - 0.0.0-master-dev534
    - 0.0.0-master-dev535
    - 1.1.0-alpha1-dev536
    - 0.0.0-master-dev537
    - 0.0.0-master-dev538
    - 0.0.0-mpp-dev539
    - 1.0.1
    - 0.0.0-mpp-rebase-2021-dec-23-dev541
    - 0.0.0-master-dev542
    - 0.0.0-mpp-dev543
    - 1.1.0-alpha1-dev544
    - 1.1.0-alpha1-dev545
    - 0.0.0-mpp-dev547
    - 0.0.0-mpp-build-fixes-dev546
    - 0.0.0-mpp-update-gradle-versions-dev548
    - 0.0.0-master-dev549
    - 1.1.0-alpha1-dev550
    - 0.0.0-mpp-fix-ci-issues-dev551
    - 0.0.0-mpp-fix-ci-issues-dev552
    - 0.0.0-mpp-dev553
    - 0.0.0-mpp-dev554
    - 0.0.0-master-dev555
    - 1.1.0-alpha1-dev556
    - 0.0.0-mpp_upd_demo-dev557
    - 0.0.0-master-dev558
    - 1.1.0-alpha1-dev559
    - 0.0.0-mpp-gradle-siplification-dev560
    - 0.0.0-master-dev561
    - 0.0.0-master-dev562
    - 0.0.0-master-dev563
    - 0.0.0-mpp_example_add_bouncing_balls-dev564
    - 0.0.0-feature-accessebility-win-build565
    - 0.0.0-mpp_example_add_bouncing_balls-dev566
    - $FIXED_VERSION
    - 0.0.0-master-dev568
    - 1.1.0-alpha1-dev569
    - 0.0.0-master-dev570
    - 0.0.0-master-dev571
    - 0.0.0-master-dev572
    - 0.0.0-master-dev573
    - 0.0.0-master-dev574
    - 0.0.0-mpp-examples-dev575
    - 0.0.0-master-dev576
    - 0.0.0-master-dev577
    - 1.2.0-alpha1-dev578
    - 0.0.0-release-1.1-dev579
    - 0.0.0-master-dev580
    - 0.0.0-master-dev581
    - 0.0.0-release-1.1-dev582
    - 0.0.0-release-1.1-dev583
    - 0.0.0-release-1.1-dev584
    - 0.0.0-release-1.1-dev585
    - 0.0.0-release-1.1-dev586
    - 0.0.0-release-1.1-dev587
    - 0.0.0-release-1.1-dev588
    - 0.0.0-release-1.1-dev589
    - 0.0.0-release-1.1-dev590
    - 0.0.0-master-dev591
    - 1.1.0-alpha01
    - 1.1.0-alpha02
    - 0.0.0-master-dev596
    - 1.2.0-alpha01-dev597
    - 1.1.0-alpha03
    - 0.0.0-master-dev600
    - 0.0.0-master-dev601
    - 1.2.0-alpha01-dev602
    - 0.0.0-master-dev603
    - 1.2.0-alpha01-dev604
    - 0.0.0-master-dev605
    - 1.2.0-alpha01-dev606
    - 0.0.0-master-dev607
    - 1.2.0-alpha01-dev608
    - 1.2.0-alpha01-dev609
    - 0.0.0-master-dev610
    - 0.0.0-master-dev611
    - 1.1.0-alpha04
    - 0.0.0-master-dev613
    - 0.0.0-master-dev614
    - 0.0.0-master-dev615
    - 0.0.0-master-dev616
    - 1.2.0-alpha01-dev617
    - 0.0.0-master-dev618
    - 1.2.0-alpha01-dev619
    - 1.2.0-alpha01-dev620
    - 0.0.0-master-dev621
    - 1.1.0-alpha05
    - 0.0.0-master-dev623
    - 0.0.0-master-dev624
    - 1.2.0-alpha01-dev625
    - 1.1.0-rc01
    - 0.0.0-master-dev628
    - 1.2.0-alpha01-dev629
    - 0.0.0-master-dev630
    - 0.0.0-master-dev631
    - 1.1.0
    - 0.0.0-master-dev634
    - 0.0.0-master-dev635
    - 1.2.0-alpha01-dev636
    - 0.0.0-master-dev637
    - 0.0.0-master-dev638
    - 0.0.0-master-dev639
    - 1.2.0-alpha01-dev640
    - 0.0.0-master-dev641
    - 0.0.0-master-dev642
    - 1.1.1
    - 0.0.0-master-dev644
    - 0.0.0-master-dev645
    - 1.2.0-alpha01-dev646
    - 0.0.0-master-dev647
    - 0.0.0-master-dev648
    - 1.2.0-alpha01-dev649
    - 0.0.0-master-dev650
    - 1.2.0-alpha01-dev651
    - 0.0.0-master-dev652
    - 0.0.0-on_rebase_2022_march_17-dev653
    - 0.0.0-master-dev654
    - 0.0.0-sync-2022-04-04-dev655
    - 0.0.0-sync-2022-04-04-dev657
    - 0.0.0-master-dev658
    - 1.2.0-alpha01-dev659
    - 0.0.0-master-dev660
    - 0.0.0-master-dev661
    - 1.2.0-alpha01-dev662
    - 0.0.0-master-dev663
    - 0.0.0-on-rebase-12-apr-2022-dev664
    - 0.0.0-on-rebase-12-apr-2022-dev665
    - 0.0.0-master-dev666
    - 1.2.0-alpha01-dev667
    - 0.0.0-on-rebase-12-apr-2022-dev668
    - 0.0.0-master-dev669
    - 0.0.0-on-rebase-12-apr-2022-dev670
    - 0.0.0-master-dev671
    - 0.0.0-master-dev672
    - 0.0.0-master-dev673
    - 0.0.0-master-dev674
    - 1.2.0-alpha01-dev675
    - 0.0.0-master-dev676
    - 0.0.0-master-dev677
    - 0.0.0-master-dev678
    - 1.2.0-alpha01-dev679
    - 0.0.0-master-dev680
    - 0.0.0-master-dev681
    - 1.2.0-alpha01-dev682
    - 1.2.0-alpha01-dev683
    - 0.0.0-master-dev684
    - 0.0.0-master-dev685
    - 1.2.0-alpha01-dev686
    - 0.0.0-master-dev687
    - 0.0.0-master-dev688
    - 0.0.0-master-dev689
    - 0.0.0-custom-focusInterop-dev690
    - 0.0.0-master-dev691
    - 1.2.0-alpha01-dev692
    - 0.0.0-master-dev693
    - 0.0.0-custom-focusInterop-dev695
    - 0.0.0-master-dev699
    - 0.0.0-custom-focusInterop-dev700
    - 0.0.0-master-dev701
    - 0.0.0-custom-focusInterop-dev702
    - 1.2.0-alpha01-dev703
    - 0.0.0-master-dev704
    - 0.0.0-on_kotlin_1.7.0-rc-dev705
    - 0.0.0-master-dev706
    - 1.2.0-alpha01-dev707
    - 0.0.0-custom-focusTest2-dev708
    - 1.2.0-alpha01-dev709
    - 0.0.0-master-dev710
    - 0.0.0-master-dev711
    - 1.2.0-alpha01-dev712
    - 1.2.0-alpha01-dev713
    - 0.0.0-master-dev714
    - 0.0.0-master-dev715
    - 1.2.0-alpha01-dev716
    - 0.0.0-master-dev717
    - 0.0.0-master-dev718
    - 0.0.0-igordmn-patch-3-dev720
    - 0.0.0-igordmn-patch-3-dev721
    - 0.0.0-igordmn-patch-3-dev722
    - 0.0.0-master-dev723
    - 1.2.0-alpha01-dev724
    - 1.2.0-alpha01-dev725
    - 0.0.0-master-dev726
    - 0.0.0-master-dev727
    - 0.0.0-master-dev728
    - 1.2.0-alpha01-dev729
    - 0.0.0-release1.2-integration-dev730
    - 1.2.0-alpha01-dev731
    - 0.0.0-master-dev733
    - 0.0.0-release1.2-integration-dev732
    - 0.0.0-release1.2-integration-dev734
    - 0.0.0-master-dev735
    - 0.0.0-release1.2-integration-dev736
    - 0.0.0-release1.2-integration-dev737
    - 0.0.0-master-dev738
    - 0.0.0-master-dev739
    - 1.2.0-alpha01-dev740
    - 1.2.0-alpha01-dev741
    - 0.0.0-master-dev742
    - 0.0.0-master-dev743
    - 0.0.0-master-dev744
    - 1.2.0-alpha01-dev745
    - 0.0.0-master-dev746
    - 1.2.0-alpha01-dev747
    - 1.2.0-alpha01-dev748
    - 0.0.0-master-dev749
    - 1.2.0-alpha01-dev750
    - 0.0.0-master-dev751
    - 0.0.0-master-dev752
    - 1.2.0-alpha01-dev753
    - 0.0.0-master-dev754
    - 1.2.0-alpha01-dev755
    - 0.0.0-master-dev756
    - 0.0.0-feature-useDifferentCompiler-dev757
    - 0.0.0-sync-androidx-1.2.1-dev758
    - 0.0.0-sync-androidx-1.2.1-dev759
    - 0.0.0-sync-androidx-1.2.1-dev760
    - 0.0.0-sync-androidx-1.2.1-dev761
    - 0.0.0-sync-androidx-1.2.1-dev762
    - 0.0.0-master-dev763
    - 1.2.0-alpha01-dev764
    - 1.2.0-alpha01-dev765
    - 1.2.0-alpha01-dev766
    - 1.2.0-alpha01-dev767
    - 1.2.0-alpha01-dev768
    - 1.2.0-alpha01-dev770
    - 0.0.0-master-dev772
    - 0.0.0-master-dev773
    - 1.2.0-alpha01-dev774
    - 0.0.0-master-dev775
    - 0.0.0-master-dev776
    - 0.0.0-master-dev777
    - 1.2.0-alpha01-dev778
    - 0.0.0-master-dev779
    - 0.0.0-master-dev782
    - 0.0.0-master-dev783
    - 0.0.0-master-dev784
    - 0.0.0-master-dev785
    - 1.2.0-alpha01-dev786
    - 0.0.0-master-dev787
    - 0.0.0-master-dev788
    - 1.2.0-beta01
    - 0.0.0-master-dev793
    - 0.0.0-master-dev794
    - 1.2.0-beta02-dev795
    - 0.0.0-master-dev796
    - 0.0.0-master-dev797
    - 1.2.0-beta02-dev798
    - 0.0.0-master-dev799
    - 1.2.0-beta02
    - 0.0.0-master-dev801
    - 0.0.0-master-dev802
    - 1.2.0-beta03-dev803
    - 1.2.0-beta03
    - 0.0.0-master-dev806
    - 0.0.0-master-dev807
    - 0.0.0-master-dev808
    - 0.0.0-release-1.2-dev809
    - 0.0.0-release-1.2-dev810
    - 0.0.0-release-1.2-dev811
    - 0.0.0-release-1.2-dev812
    - 0.0.0-master-dev813
    - 1.2.0-rc01
    - 0.0.0-master-dev815
    - 1.2.0-rc02-dev816
    - 1.2.0-rc02
    - 1.2.0
    - 0.0.0-master-dev820
    - 0.0.0-master-dev821
    - 0.0.0-master-dev822
    - 0.0.0-master-dev823
    - 1.3.0-alpha01-dev824
    - 0.0.0-master-dev825
    - 0.0.0-master-dev826
    - 1.3.0-alpha01-dev827
    - 0.0.0-master-dev828
    - 0.0.0-master-dev829
    - 0.0.0-master-dev830
    - 1.3.0-alpha01-dev831
    - 1.3.0-alpha01-dev832
    - 0.0.0-master-dev833
    - 1.3.0-alpha01-dev834
    - 0.0.0-rebase_on_1.3-dev835
    - 0.0.0-rebase_on_1.3-dev836
    - 0.0.0-rebase_on_1.3-dev837
    - 1.2.1-rc01
    - 1.2.1-rc02
    - 0.0.0-master-dev840
    - 0.0.0-rebase_on_1.3-dev841
    - 0.0.0-rebase_on_1.3-dev842
    - 1.2.1-rc03
    - 0.0.0-rebase_on_1.3-dev844
    - 0.0.0-master-dev845
    - 0.0.0-master-dev846
    - 1.2.1
    - 0.0.0-master-dev848
    - 1.3.0-alpha01-dev849
    - 0.0.0-master-dev850
    - 0.0.0-master-dev851
    - 0.0.0-master-dev852
    - 1.3.0-alpha01-dev853
    - 1.3.0-beta01
    - 0.0.0-release-1.3.0-beta-dev855
    - 0.0.0-master-dev856
    - 1.3.0-beta02
    - 1.3.0-beta03
    - 0.0.0-master-dev860
    - 1.3.0-alpha01-dev861
    - 1.3.0-alpha01-dev862
    - 0.0.0-master-dev863
    - 0.0.0-master-dev864
    - 0.0.0-master-dev865
    - 1.3.0-alpha01-dev866
    - 1.3.0-alpha01-dev868
    - 1.3.0-alpha01-dev869
    - 0.0.0-master-dev870
    - 1.3.0-beta04-dev871
    - 0.0.0-master-dev872
    - 1.3.0-beta04-dev873
    - 0.0.0-master-dev874
    - 1.3.0-beta04-dev875
    - 0.0.0-master-dev876
    - 1.3.0-beta04-dev877
    - 0.0.0-master-878
    - 1.3.0-beta04-dev879
    - 0.0.0-master-dev881
    - 1.3.0-beta04-dev880
    - 1.3.0-beta04-dev882
    - 1.3.0-beta04-dev883
    - 0.0.0-master-dev884
    - 1.3.0-beta04-dev885
    - 0.0.0-master-dev886
    - 0.0.0-master-dev887
    - 0.0.0-master-dev888
    - 1.3.0-beta04-dev889
    - 1.2.2-rc01
    - 1.3.0-rc01
    - 0.0.0-master-dev892
    - 1.2.2
    - 0.0.0-master-dev894
    - 0.0.0-master-dev895
    - 0.0.0-master-dev896
    - 1.3.0-beta04-dev897
    - 0.0.0-master-dev898
    - 0.0.0-master-dev899
    - 0.0.0-master-dev900
    - 1.3.0-beta04-dev901
    - 0.0.0-master-dev902
    - 1.3.0-beta04-dev903
    - 0.0.0-master-dev904
    - 0.0.0-master-dev905
    - 1.3.0-rc02-dev906
    - 0.0.0-master-dev907
    - 1.3.0-rc02
    - 0.0.0-master-dev910
    - 0.0.0-master-dev911
    - 0.0.0-master-dev912
    - 1.3.0-rc02-dev913
    - 1.3.0-rc03
    - 1.3.0-rc04
    - 1.3.0-rc05
    - 0.0.0-master-dev917
    - 0.0.0-master-dev921
    - 0.0.0-master-dev922
    - 1.4.0-alpha01-dev924
    - 0.0.0-master-dev925
    - 1.3.0-rc06
    - 1.3.0
    - 0.0.0-master-dev928
    - 1.4.0-alpha01-dev929
    - 0.0.0-master-dev930
    - 0.0.0-master-dev931
    - 0.0.0-master-dev932
    - 1.4.0-alpha01-dev933
    - 0.0.0-master-dev934
    - 0.0.0-master-dev935
    - 0.0.0-master-dev936
    - 1.4.0-alpha01-dev937
    - 1.4.0-alpha01-dev938
    - 0.0.0-master-dev939
    - 1.4.0-alpha01-dev940
    - 0.0.0-master-dev941
    - 1.4.0-alpha01-dev942
    - 0.0.0-master-dev943
    - 0.0.0-master-dev944
    - 0.0.0-master-dev945
    - 0.0.0-master-dev946
    - 1.4.0-alpha01-dev947
    - 0.0.0-master-dev948
    - 0.0.0-master-dev949
    - 1.4.0-alpha01-dev950
    - 0.0.0-master-dev951
    - 1.3.1-beta01
    - 1.3.1-rc01
    - 1.4.0-alpha01-dev954
    - 0.0.0-master-dev955
    - 0.0.0-master-dev956
    - 0.0.0-master-dev957
    - 1.4.0-alpha01-dev958
    - 0.0.0-master-dev959
    - 0.0.0-master-dev960
    - 1.3.1-rc02
    - 0.0.0-master-dev962
    - 0.0.0-master-dev963
    - 0.0.0-master-dev964
    - 0.0.0-master-dev965
    - 1.4.0-alpha01-dev966
    - 1.3.1-rc03
    - 1.4.0-alpha01-dev968
    - 0.0.0-master-dev969
    - 0.0.0-master-dev970
    - 1.3.1
    - 1.4.0-alpha01-dev972
    - 0.0.0-master-dev973
    - 0.0.0-master-dev974
    - 1.4.0-alpha01-dev975
    - 0.0.0-master-dev976
    - 1.4.0-alpha01-dev977
    - 0.0.0-master-dev978
    - 0.0.0-master-dev979
    - 1.4.0-alpha01-dev980
    - 0.0.0-master-dev981
    - 0.0.0-master-dev982
    - 0.0.0-master-dev983
    - 1.4.0-alpha01-dev984
    - 1.4.0-alpha01-dev985
    - 0.0.0-master-dev986
    - 0.0.0-master-dev987
    - 1.4.0-alpha01-dev986
    - 1.4.0-alpha01-dev988
    - 1.4.0-alpha01-dev989
    - 1.4.0-alpha01-dev990
    - 1.4.0-alpha01-dev991
    - 1.4.0-alpha01-dev992
    - 1.4.0-alpha01-dev993
    - 0.0.0-master-dev996
    - 1.4.0-alpha01-dev999
    - 1.4.0-alpha01-dev1000
    - 0.0.0-master-dev1001
    - 1.4.0-alpha01-dev1003
    - 1.4.0-alpha01-dev1004
    - 0.0.0-master-dev1005
    - 0.0.0-master-dev1006
    - 0.0.0-master-dev1007
    - 1.4.0-alpha01-dev1008
    - 1.4.0-rc01
    - 0.0.0-master-dev1010
    - 0.0.0-igor.demin-rename-web-to-html-dev1012
    - 0.0.0-master-dev1013
    - 0.0.0-igor.demin-rename-web-to-html-dev1014
    - 1.4.0-rc02
    - 0.0.0-master-dev1017
    - 1.4.0-rc03
    - 0.0.0-master-dev1020
    - 0.0.0-master-dev1021
    - 0.0.0-master-dev1022
    - 1.4.0-rc04-dev1023
    - 0.0.0-master-dev1024
```

</p>
</details>

### org.jetbrains.compose v1.4.0 (After)

As you can see, it will drop some newer dev builds. However, I doubt that no one will use these except JetBrains' developers. Therefore, this submission will have no code to distinguish the new dev build. If you have any ideas feel free to create an issue.

```yaml
plugins:
  org.jetbrains.compose:
    - 1.5.0-dev1036
    - 1.5.0-dev1035
    - 1.5.0-dev1030
```
